### PR TITLE
docs: update docs to reflect copier refactor

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Contributing to scaf
+
+### Nix Flake
+
+scaf provides a Nix Flake to install all the required packages for development.
+The Nix Flake ensures all developers are using the same versions of all packages
+to develop on Scaf in an isolated environment.
+
+Follow the instructions to install
+[Nix](https://nixos.org/download/#download-nix) for your OS.
+
+1. Ensure you have a recent version of Nix installed:
+
+Nix Flakes are available in recent versions of Nix. You can check your Nix
+version using:
+
+```sh
+nix --version
+```
+
+If you need to install or update Nix, you can follow the instructions on the Nix
+installation page.
+
+2. Enable experimental features:
+
+You need to enable the experimental features in your Nix configuration. To do
+this, add the following lines to your ~/.config/nix/nix.conf file. If the file
+doesn't exist, you can create it:
+
+```ini
+experimental-features = nix-command flakes
+```
+
+3. Using Nix Flakes:
+
+Once you have enabled the experimental features, you can use Nix Flakes with the
+nix command. For example:
+
+```sh
+nix flake show
+```
+
+This command will display information about the flake in the current directory
+if you have a flake.nix file.
+
+Finally, install [Direnv](https://direnv.net/) and run `direnv allow`. The
+direnv configuration in `.envrc` will use the flake to install the required
+packages.
+
+### Testing
+
+To test the copier portion of Scaf, run the `./test-scaf.sh` script.
+
+If you are not using the Nix development environment, create a virtual environment and
+install black, isort and copier before running `./test-scaf.sh`.
+
+Running `./test-scaf.sh -h` shows the usage instructions:
+
+```shell
+Usage: ./test-scaf.sh -t <template_folder> [-o <output_folder>] [-d <test_data>] [-h]
+  -t <template_folder> Required: Specify the source folder for the template
+  -o <output_folder>   Optional: Specify the output folder (default is /tmp/scaf-test)
+  -d <test_data>       Optional: Specify a preset answers data file
+  -h                   Show this help message
+```

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
   <img src="scaf-logo.png" width="250px">
 </p>
 
-Usage: scaf project_slug [OPTIONS] [TEMPLATE]
-
 **scaf** is a template manager that simplifies bootstrapping and updating projects.
 
 ## Features:
@@ -24,12 +22,13 @@ Installation is supported on Linux and macOS:
 curl -sSL https://raw.githubusercontent.com/sixfeetup/scaf/main/install.sh | bash
 ```
 
-The installation script will install kubectl, kind, Tilt and uv if it can't
-be found on your system.
+The installation script will install kubectl, kind, Tilt and uv if it can't be
+found on your system.
 
 ## Creating a new project using this repo
 
-Run `scaf myproject`, answer all the questions, and you'll have your new project!
+Run `scaf myproject`, answer all the questions, and you'll have your new
+project!
 
 Refer to the documentation of the template you installed.
 
@@ -74,69 +73,6 @@ Examples:
       # REPO_URL must be one of the allowed template URLs above.
 ```
 
-## Development on Scaf
+## Contributing
 
-### Nix Flake
-
-scaf provides a Nix Flake to install all the required packages for development.
-The Nix Flake ensures all developers are using the same versions of all packages
-to develop on Scaf in an isolated environment.
-
-Follow the instructions to install
-[Nix](https://nixos.org/download/#download-nix) for your OS.
-
-1. Ensure you have a recent version of Nix installed:
-
-Nix Flakes are available in recent versions of Nix. You can check your Nix
-version using:
-
-```sh
-nix --version
-```
-
-If you need to install or update Nix, you can follow the instructions on the Nix
-installation page.
-
-2. Enable experimental features:
-
-You need to enable the experimental features in your Nix configuration. To do
-this, add the following lines to your ~/.config/nix/nix.conf file. If the file
-doesn't exist, you can create it:
-
-```ini
-experimental-features = nix-command flakes
-```
-
-3. Using Nix Flakes:
-
-Once you have enabled the experimental features, you can use Nix Flakes with the
-nix command. For example:
-
-```sh
-nix flake show
-```
-
-This command will display information about the flake in the current directory
-if you have a flake.nix file.
-
-Finally, install [Direnv](https://direnv.net/) and run `direnv allow`. The
-direnv configuration in `.envrc` will use the flake to install the required
-packages.
-
-### Testing
-
-To test the copier portion of Scaf, run the `./test-scaf.sh` script.
-
-If you are not using the Nix development environment, create a virtual environment and
-install black, isort and copier before running `./test-scaf.sh`.
-
-Running `./test-scaf.sh -h` shows the usage instructions:
-
-```shell
-Usage: ./test-scaf.sh -t <template_folder> [-o <output_folder>] [-d <test_data>] [-h]
-  -t <template_folder> Required: Specify the source folder for the template
-  -o <output_folder>   Optional: Specify the output folder (default is /tmp/scaf-test)
-  -d <test_data>       Optional: Specify a preset answers data file
-  -h                   Show this help message
-```
-
+Please see [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute.


### PR DESCRIPTION
## :dart: What needed to be done and why?

The docs were out of date after the copier and template refactors.

## :new: What is changed by this PR?

- Remove fullstack template docs

- Adds a new "Usage" section to the README.md file, which includes the information from the scaf script's help message. This makes the documentation more complete and accurate.